### PR TITLE
Fix warning for golint.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -18,7 +18,7 @@ import (
 
 var cutNewlineReplacer = strings.NewReplacer("\r", "", "\n", "")
 
-func StructToJson(i interface{}) string {
+func StructToJSON(i interface{}) string {
 	j, err := json.Marshal(i)
 	if err != nil {
 		return ""

--- a/common/error.go
+++ b/common/error.go
@@ -3,8 +3,8 @@ package common
 import "errors"
 
 var (
-	NoContainer = errors.New("No container")
-	NoImage     = errors.New("No image")
-	NoVolume    = errors.New("No volume")
-	NoNetwork   = errors.New("No network")
+	ErrNoContainer = errors.New("No container")
+	ErrNoImage     = errors.New("No image")
+	ErrNoVolume    = errors.New("No volume")
+	ErrNoNetwork   = errors.New("No network")
 )

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	"github.com/skanehira/docui/common"
 )
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,12 +1,11 @@
 package docker
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	docker "github.com/fsouza/go-dockerclient"
+	"github.com/fsouza/go-dockerclient"
 	"github.com/skanehira/docui/common"
 )
 
@@ -215,7 +214,7 @@ func (d *Docker) RemoveDanglingImages() error {
 	}
 
 	if len(errids) > 1 {
-		return errors.New(fmt.Sprintf("can not remove ids\n%s", errids))
+		return fmt.Errorf("can not remove ids\n%s", errids)
 	}
 
 	return nil

--- a/panel/containerPanel.go
+++ b/panel/containerPanel.go
@@ -165,7 +165,7 @@ func (c *ContainerList) selected() (*Container, error) {
 	length := len(c.Containers)
 
 	if index >= length {
-		return nil, common.NoContainer
+		return nil, common.ErrNoContainer
 	}
 	return c.Containers[cy+oy], nil
 }

--- a/panel/imagePanel.go
+++ b/panel/imagePanel.go
@@ -184,7 +184,7 @@ func (i *ImageList) selected() (*Image, error) {
 	length := len(i.Images)
 
 	if index >= length {
-		return nil, common.NoImage
+		return nil, common.ErrNoImage
 	}
 
 	return i.Images[index], nil
@@ -699,7 +699,7 @@ func (i *ImageList) RemoveImage(g *gocui.Gui, v *gocui.View) error {
 
 func (i *ImageList) RemoveDanglingImages(g *gocui.Gui, v *gocui.View) error {
 	if len(i.Images) == 0 {
-		i.ErrMessage(common.NoImage.Error(), i.name)
+		i.ErrMessage(common.ErrNoImage.Error(), i.name)
 		return nil
 	}
 

--- a/panel/infoPanel.go
+++ b/panel/infoPanel.go
@@ -61,15 +61,15 @@ func (i *Info) SetView(g *gocui.Gui) error {
 	return nil
 }
 
-func (info *Info) Name() string {
-	return info.name
+func (i *Info) Name() string {
+	return i.name
 }
 
-func (info *Info) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+func (i *Info) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
 	// do nothing
 }
 
-func (info *Info) Refresh(g *gocui.Gui, v *gocui.View) error {
+func (i *Info) Refresh(g *gocui.Gui, v *gocui.View) error {
 	// do nothing
 	return nil
 }

--- a/panel/networkPanel.go
+++ b/panel/networkPanel.go
@@ -154,7 +154,7 @@ func (n *NetworkList) selected() (*Network, error) {
 	length := len(n.Networks)
 
 	if index >= length {
-		return nil, common.NoNetwork
+		return nil, common.ErrNoNetwork
 	}
 
 	return n.Networks[index], nil

--- a/panel/volumePanel.go
+++ b/panel/volumePanel.go
@@ -146,7 +146,7 @@ func (vl *VolumeList) selected() (*Volume, error) {
 	length := len(vl.Volumes)
 
 	if index >= length {
-		return nil, common.NoVolume
+		return nil, common.ErrNoVolume
 	}
 	return vl.Volumes[cy+oy], nil
 }
@@ -289,8 +289,8 @@ func (vl *VolumeList) RemoveVolume(g *gocui.Gui, v *gocui.View) error {
 
 func (vl *VolumeList) PruneVolumes(g *gocui.Gui, v *gocui.View) error {
 	if len(vl.Volumes) == 0 {
-		vl.ErrMessage(common.NoVolume.Error(), vl.name)
-		vl.Logger.Error(common.NoVolume.Error(), vl.name)
+		vl.ErrMessage(common.ErrNoVolume.Error(), vl.name)
+		vl.Logger.Error(common.ErrNoVolume.Error(), vl.name)
 		return nil
 	}
 


### PR DESCRIPTION
# Overview

Fixes: #57 

```
common/common.go:21:6: func StructToJson should be StructToJSON (golint)
func StructToJson(i interface{}) string {
     ^
common/error.go:6:2: error var NoContainer should have name of the form ErrFoo (golint)
	NoContainer = errors.New("No container")
	^
common/error.go:7:2: error var NoImage should have name of the form ErrFoo (golint)
	NoImage     = errors.New("No image")
	^
common/error.go:8:2: error var NoVolume should have name of the form ErrFoo (golint)
	NoVolume    = errors.New("No volume")
	^
common/error.go:9:2: error var NoNetwork should have name of the form ErrFoo (golint)
	NoNetwork   = errors.New("No network")
	^
docker/docker.go:218:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...) (golint)
		return errors.New(fmt.Sprintf("can not remove ids\n%s", errids))
		       ^
panel/infoPanel.go:64:1: receiver name info should be consistent with previous receiver name i for Info (golint)
func (info *Info) Name() string {
^
panel/infoPanel.go:68:1: receiver name info should be consistent with previous receiver name i for Info (golint)
func (info *Info) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
^
panel/infoPanel.go:72:1: receiver name info should be consistent with previous receiver name i for Info (golint)
func (info *Info) Refresh(g *gocui.Gui, v *gocui.View) error {
^
```

## Reference link

* [Effective Go](https://golang.org/doc/effective_go.html)
* [CodeReviewComments](https://golang.org/wiki/CodeReviewComments)
