### PR TITLE
Add a validation of a panel size

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -222,3 +222,20 @@ func IsTerminalWindowSizeThanZero() bool {
 		}
 	}
 }
+
+// IsValidPanelSize checks if a panel size is valid.
+func IsValidPanelSize(x0, y0, x1, y1 int) error {
+	if x0 >= x1 || y0 >= y1 {
+		return ErrSmallTerminalWindowSize
+	}
+	return nil
+}
+
+// SetViewWithValidPanelSize run SetView with a valid panel size.
+func SetViewWithValidPanelSize(g *gocui.Gui, name string, x0, y0, x1, y1 int) (*gocui.View, error) {
+	if err := IsValidPanelSize(x0, y0, x1, y1); err != nil {
+		panic(err)
+	}
+	v, err := g.SetView(name, x0, y0, x1, y1)
+	return v, err
+}

--- a/common/common.go
+++ b/common/common.go
@@ -224,18 +224,18 @@ func IsTerminalWindowSizeThanZero() bool {
 }
 
 // IsValidPanelSize checks if a panel size is valid.
-func IsValidPanelSize(x0, y0, x1, y1 int) error {
-	if x0 >= x1 || y0 >= y1 {
+func IsValidPanelSize(x, y, w, h int) error {
+	if x >= w || y >= h {
 		return ErrSmallTerminalWindowSize
 	}
 	return nil
 }
 
 // SetViewWithValidPanelSize run SetView with a valid panel size.
-func SetViewWithValidPanelSize(g *gocui.Gui, name string, x0, y0, x1, y1 int) (*gocui.View, error) {
-	if err := IsValidPanelSize(x0, y0, x1, y1); err != nil {
+func SetViewWithValidPanelSize(g *gocui.Gui, name string, x, y, w, h int) (*gocui.View, error) {
+	if err := IsValidPanelSize(x, y, w, h); err != nil {
 		panic(err)
 	}
-	v, err := g.SetView(name, x0, y0, x1, y1)
+	v, err := g.SetView(name, x, y, w, h)
 	return v, err
 }

--- a/common/error.go
+++ b/common/error.go
@@ -13,4 +13,6 @@ var (
 	ErrNoNetwork = errors.New("no network")
 	// ErrDockerConnect cannot connect to docker engine error.
 	ErrDockerConnect = errors.New("unable to connect to Docker")
+	// ErrSmallTerminalWindowSize cannot run docui because of a small terminal window size
+	ErrSmallTerminalWindowSize = errors.New("unable to run docui because of a small terminal window size")
 )

--- a/panel/containerPanel.go
+++ b/panel/containerPanel.go
@@ -78,7 +78,7 @@ func (c *ContainerList) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Mo
 // SetView set up container list panel.
 func (c *ContainerList) SetView(g *gocui.Gui) error {
 	// set header panel
-	if v, err := g.SetView(ContainerListHeaderPanel, c.x, c.y, c.w, c.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, ContainerListHeaderPanel, c.x, c.y, c.w, c.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			c.Logger.Error(err)
 			return err
@@ -92,7 +92,7 @@ func (c *ContainerList) SetView(g *gocui.Gui) error {
 	}
 
 	// set scroll panel
-	v, err := g.SetView(c.name, c.x, c.y+1, c.w, c.h)
+	v, err := common.SetViewWithValidPanelSize(g, c.name, c.x, c.y+1, c.w, c.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			c.Logger.Error(err)

--- a/panel/detailPanel.go
+++ b/panel/detailPanel.go
@@ -2,6 +2,7 @@ package panel
 
 import (
 	"github.com/jroimartin/gocui"
+	"github.com/skanehira/docui/common"
 )
 
 // Detail panel
@@ -23,7 +24,7 @@ func (d Detail) Name() string {
 
 // SetView set up detail panel.
 func (d Detail) SetView(g *gocui.Gui) error {
-	v, err := g.SetView(d.Name(), d.x, d.y, d.w, d.h)
+	v, err := common.SetViewWithValidPanelSize(g, d.Name(), d.x, d.y, d.w, d.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err

--- a/panel/imagePanel.go
+++ b/panel/imagePanel.go
@@ -84,7 +84,7 @@ func (i *ImageList) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifi
 // SetView set up image list panel.
 func (i *ImageList) SetView(g *gocui.Gui) error {
 	// set header panel
-	if v, err := g.SetView(ImageListHeaderPanel, i.x, i.y, i.w, i.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, ImageListHeaderPanel, i.x, i.y, i.w, i.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			i.Logger.Error(err)
 			return err
@@ -98,7 +98,7 @@ func (i *ImageList) SetView(g *gocui.Gui) error {
 	}
 
 	// set scroll panel
-	v, err := g.SetView(i.name, i.x, i.y+1, i.w, i.h)
+	v, err := common.SetViewWithValidPanelSize(g, i.name, i.x, i.y+1, i.w, i.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			i.Logger.Error(err)

--- a/panel/infoPanel.go
+++ b/panel/infoPanel.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/jroimartin/gocui"
+	"github.com/skanehira/docui/common"
 )
 
 // Info have docui and docker info.
@@ -45,7 +46,7 @@ type HostInfo struct {
 
 // SetView set up info panel.
 func (i *Info) SetView(g *gocui.Gui) error {
-	v, err := g.SetView(i.name, i.x, i.y, i.w, i.h)
+	v, err := common.SetViewWithValidPanelSize(g, i.name, i.x, i.y, i.w, i.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err

--- a/panel/navigatePanel.go
+++ b/panel/navigatePanel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jroimartin/gocui"
+	"github.com/skanehira/docui/common"
 )
 
 // Navigate navigate panel.
@@ -31,7 +32,7 @@ func (n Navigate) Name() string {
 
 // SetView set up navigate panel.
 func (n Navigate) SetView(g *gocui.Gui) error {
-	v, err := g.SetView(n.name, n.x, n.y, n.w, n.h)
+	v, err := common.SetViewWithValidPanelSize(g, n.name, n.x, n.y, n.w, n.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			return err

--- a/panel/networkPanel.go
+++ b/panel/networkPanel.go
@@ -74,7 +74,7 @@ func (n *NetworkList) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modi
 // SetView set up network list panel.
 func (n *NetworkList) SetView(g *gocui.Gui) error {
 	// set header panel
-	if v, err := g.SetView(NetworkListHeaderPanel, n.x, n.y, n.w, n.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, NetworkListHeaderPanel, n.x, n.y, n.w, n.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			n.Logger.Error(err)
 			return err
@@ -88,7 +88,7 @@ func (n *NetworkList) SetView(g *gocui.Gui) error {
 	}
 
 	// set scroll panel
-	v, err := g.SetView(n.name, n.x, n.y+1, n.w, n.h)
+	v, err := common.SetViewWithValidPanelSize(g, n.name, n.x, n.y+1, n.w, n.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			n.Logger.Error(err)

--- a/panel/searchImagePanel.go
+++ b/panel/searchImagePanel.go
@@ -48,7 +48,7 @@ func (s *SearchImage) Name() string {
 
 // SetView set up search image panel.
 func (s *SearchImage) SetView(g *gocui.Gui) error {
-	v, err := g.SetView(s.name, s.x, s.y, s.w, s.h)
+	v, err := common.SetViewWithValidPanelSize(g, s.name, s.x, s.y, s.w, s.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			s.Logger.Error(err)

--- a/panel/searchImageResultPanel.go
+++ b/panel/searchImageResultPanel.go
@@ -41,7 +41,7 @@ func (s *SearchImageResult) Name() string {
 // SetView set up result panel.
 func (s *SearchImageResult) SetView(g *gocui.Gui) error {
 	// set header panel
-	if v, err := g.SetView(SearchImageResultHeaderPanel, s.x, s.y, s.w, s.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, SearchImageResultHeaderPanel, s.x, s.y, s.w, s.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			s.Logger.Error(err)
 			return err
@@ -54,7 +54,7 @@ func (s *SearchImageResult) SetView(g *gocui.Gui) error {
 	}
 
 	// set scroll panel
-	if v, err := g.SetView(s.name, s.x, s.y+1, s.w, s.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, s.name, s.x, s.y+1, s.w, s.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			s.Logger.Error(err)
 			return err

--- a/panel/task.go
+++ b/panel/task.go
@@ -73,7 +73,7 @@ func NewTaskList(gui *Gui, name string, x, y, w, h int) *TaskList {
 // SetView set up task list panel.
 func (t *TaskList) SetView(g *gocui.Gui) error {
 	// set header panel
-	if v, err := g.SetView(TaskListHeaderPanel, t.x, t.y, t.w, t.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, TaskListHeaderPanel, t.x, t.y, t.w, t.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			t.Logger.Error(err)
 			return err
@@ -87,7 +87,7 @@ func (t *TaskList) SetView(g *gocui.Gui) error {
 	}
 
 	// set scroll panel
-	v, err := g.SetView(t.name, t.x, t.y+1, t.w, t.h)
+	v, err := common.SetViewWithValidPanelSize(g, t.name, t.x, t.y+1, t.w, t.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			t.Logger.Error(err)

--- a/panel/volumePanel.go
+++ b/panel/volumePanel.go
@@ -74,7 +74,7 @@ func (vl *VolumeList) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modi
 // SetView set up volume list panel.
 func (vl *VolumeList) SetView(g *gocui.Gui) error {
 	// set header panel
-	if v, err := g.SetView(VolumeListHeaderPanel, vl.x, vl.y, vl.w, vl.h); err != nil {
+	if v, err := common.SetViewWithValidPanelSize(g, VolumeListHeaderPanel, vl.x, vl.y, vl.w, vl.h); err != nil {
 		if err != gocui.ErrUnknownView {
 			vl.Logger.Error(err)
 			return err
@@ -88,7 +88,7 @@ func (vl *VolumeList) SetView(g *gocui.Gui) error {
 	}
 
 	// set scroll panel
-	v, err := g.SetView(vl.name, vl.x, vl.y+1, vl.w, vl.h)
+	v, err := common.SetViewWithValidPanelSize(g, vl.name, vl.x, vl.y+1, vl.w, vl.h)
 	if err != nil {
 		if err != gocui.ErrUnknownView {
 			vl.Logger.Error(err)


### PR DESCRIPTION
fix #76 

According to https://github.com/jroimartin/gocui/issues/85, gocui raises `invalid dimensions` error with [gocui#Gui.SetView](https://godoc.org/github.com/jroimartin/gocui#Gui.SetView).

So, this PR adds a wrapper method to check if a panel size is valid and raises a error before running `gocui#Gui.SetView`.

The logic of `common#IsValidPanelSize` is the same as [gocui#Gui.SetView validation codes](https://github.com/jroimartin/gocui/blob/c055c87ae801372cd74a0839b972db4f7697ae5f/gui.go#L131-L133) not to change a process of gocui#Gui.SetView.