### PR TITLE
Add snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.swp
+*.snap
 .idea
 dist/
-
+/prime/
+/stage/
+/parts/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ $ brew tap skanehira/docui
 $ brew install docui
 ```
 
+### Snapd
+
+```sh
+$ snap install docui --classic
+```
+
 ## Update
 
 Use git pull:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: docui
+version-script: |
+  git describe --tag | awk -F'-([1-9]|g)' '{print $1}'
+version: latest
+summary:  docui is TUI Client for Docker.
+description: |
+  docui is TUI Client for Docker.
+grade: stable
+confinement: classic
+
+build-packages:
+  - git
+  - gcc
+
+parts:
+  docui:
+    source: .
+    plugin: go
+    go-importpath: github.com/skanehira/docui
+    build-snaps:
+      - go/latest/stable
+
+apps:
+  docui:
+    command: docui


### PR DESCRIPTION
I made snapcraft.yaml so that we can use docui with snap.
It is set to build snap based on the latest master's commit.

snapcraft.yaml is used to create a snap locally or on snapcraft.io/build.  
For details of snapcraft format please check here.
https://docs.snapcraft.io/the-snapcraft-format/8337

When pushing master, build and snap are released automatically, 
so I recommend linking repositories with https://snapcraft.io/build.

### Note:
docui needs to set the confinement setting to classic in order to access /var/run/docker.sock of the host OS.  
Also, it seems that it is necessary to obtain approval in the forum to publish snap with classic.
https://docs.snapcraft.io/process-for-reviewing-classic-confinement-snaps/1460
https://forum.snapcraft.io/t/classic-confinement-request-for-the-git-cola-snap/7480

If you do not need formal public release immediately, changing the confinement setting to devmode will allow you to publish snap without authorization from the store.   
In that case, docui can not be found using the "snap search" command.

snapcraft.yaml
```yaml
confinement: devmode # change from classic
```
Install docui
```sh
snap install docui --beta --devmode
or 
snap install docui --edge --devmode
```