### PR TITLE
Update docker version for CVE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,4 +115,4 @@ workflows:
   docker-image-build:
     jobs:
       - build-docker-image:
-          docker-version: "18.06.0-ce"
+          docker-version: "18.09.2-ce"


### PR DESCRIPTION
Let's update the docker version for http://www.jpcert.or.jp/at/2019/at190007.html