### PR TITLE
Add goreleaser to support Homebrew installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
       - run:
           name: Run build
           command: go build
-
   lint:
     parameters:
       go-version:
@@ -100,6 +99,23 @@ jobs:
       - run:
           name: Push Image
           command: docker push skanehira/docui
+
+  release:
+    parameters:
+      go-version:
+        type: string
+
+    executor:
+      name: build
+      go-version: << parameters.go-version >>
+
+    steps:
+      - checkout
+      - go_mod_download
+      - run:
+          name: Run goreleaser
+          command: curl -sL https://git.io/goreleaser | bash -s -- --rm-dist
+
 workflows:
   stable-build:
     jobs:
@@ -109,7 +125,6 @@ workflows:
           go-version: "1.11.4"
           requires:
             - lint
-
   latest-build:
     jobs:
       - lint:
@@ -126,3 +141,15 @@ workflows:
           filters:
             branches:
               only: master
+
+  release:
+    jobs:
+      - lint:
+          go-version: "1.11.4"
+      - release:
+          go-version: "1.11.4"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /[0-9]+(\.[0-9]+)(\.[0-9]+)/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
       - run:
           name: Run build
           command: go build
+
   lint:
     parameters:
       go-version:
@@ -125,6 +126,7 @@ workflows:
           go-version: "1.11.4"
           requires:
             - lint
+
   latest-build:
     jobs:
       - lint:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .idea
+dist/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,34 @@
+project_name: docui
+builds:
+- env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  skip: true
+brew:
+  name: docui
+  github:
+    owner: skanehira
+    name: homebrew-docui
+  folder: Formula
+  description: "TUI Client for Docker"
+  homepage: "https://github.com/skanehira/docui"
+  commit_author:
+    name: goreleaserbot
+    email: goreleaser@carlosbecker.com
+  dependencies:
+    - go
+  install: |
+    bin.install "docui"
+  test: |
+    system "#{bin}/docui", "version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,4 +31,4 @@ brew:
   install: |
     bin.install "docui"
   test: |
-    system "#{bin}/docui", "version"
+    system "#{bin}/docui"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ docui can do as follows:
 - Git
 
 ## Installation
+
+### From Source
+
 If you have not installed go and set GOPATH/GOBIN,  
 you must install and set env before install docui.
 
@@ -65,6 +68,13 @@ Make sure your PATH includes the $GOPATH/bin directory so your commands can be e
 
 ```sh
 export PATH=$PATH:$GOPATH/bin
+```
+
+### Homebrew
+
+```sh
+$ brew tap skanehira/docui
+& brew install docui
 ```
 
 ## Update

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ export PATH=$PATH:$GOPATH/bin
 
 ```sh
 $ brew tap skanehira/docui
-& brew install docui
+$ brew install docui
 ```
 
 ## Update


### PR DESCRIPTION
fix #91

## Summary

This PR is to support Homebrew tap.

I researched about using Homebrew again, I knew below:

* It is necessary to set release version to use Homebrew.
* Using Homebrew tap is easier to follow the latest version than using offitial Homebrew repo.

Sorry for not able to using Homebrew with the latest commit of master branch.. 😢 

## How to use it
 
In order to be ready to use this, let me request to @skanehira to do below.

1.  Create the empty GitHub repo named `skanehira/homebrew-docui` and add empty `Formula` folder. (My test example: https://github.com/gotchane/homebrew-docui)
2. Set the Environment variable `GITHUB_TOKEN` to docui circleci project to use goreleaser.

That's all. When only pushing git tag like `1.0.x` at releasing, goreleaser is kicked from circleci, build and set binary releases to GitHub releases and update homebrew tap file.

Any comments and questions are welcome 😃 
