### PR TITLE
fixed failed to build snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,20 +5,21 @@ version: latest
 summary:  docui is TUI Client for Docker.
 description: |
   docui is TUI Client for Docker.
+
 grade: stable
 confinement: classic
 
-build-packages:
-  - git
-  - gcc
-
 parts:
   docui:
-    source: .
     plugin: go
     go-importpath: github.com/skanehira/docui
+    source: .
+    build-packages:
+      - gcc
     build-snaps:
       - go/latest/stable
+    override-build: |
+      go build -o $SNAPCRAFT_PART_INSTALL/bin/docui .
 
 apps:
   docui:


### PR DESCRIPTION
fix #103

## Removed 'git' from build-packages
It was causing git's pull to fail

## Add override-build section
override-build changes existing build methods.
$SNAPCRAFT_PART_INSTALL is the installation path of the program that passed the build.


It has been tested with local and auto build👍