### PR TITLE
fix parsing repo and tag

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -149,8 +149,10 @@ func ParsePortToString(ports []types.Port) string {
 
 // ParseRepoTag parse image repo and tag.
 func ParseRepoTag(repoTag string) (string, string) {
-	tmp := strings.SplitN(repoTag, ":", 2)
-	return tmp[0], tmp[1]
+	tmp := strings.Split(repoTag, ":")
+	tag := tmp[len(tmp)-1]
+	repo := strings.Join(tmp[0:len(tmp)-1], ":")
+	return repo, tag
 }
 
 // ParseLabels parse image labels.


### PR DESCRIPTION
I use private docker registry whose hostname has a port. (e.g. `my-host:4443`)

Before:
REPOSITORY: my-host, TAG:4443/foo/bar:latest

After:
REPOSITORY: my-host:4443/foo/bar, TAG: latest 
