### PR TITLE
Add installation method for Linux distributions other than CentOS.

### DIFF
--- a/wiki.md
+++ b/wiki.md
@@ -14,11 +14,7 @@ you have to install go and set $GOPATH and $GOBIN to ~/.bashrc.
 ```sh
 brew intall golang
 ```
-
-### Linuxbrew
-```sh
-brew intall golang
-```
+If you use `Linuxbrew` on Linux, you can install via the above command.  
 
 ### CentOS
 ```sh
@@ -59,11 +55,7 @@ https://www.docker.com/get-started
 ```sh
 brew install git
 ```
-
-### Linuxbrew
-```sh
-brew install git
-```
+If you use `Linuxbrew` on Linux, you can install via the above command.  
 
 ### CentOS
 ```sh

--- a/wiki.md
+++ b/wiki.md
@@ -14,7 +14,7 @@ you have to install go and set $GOPATH and $GOBIN to ~/.bashrc.
 ```sh
 brew intall golang
 ```
-If you use `Linuxbrew` on Linux, you can install via the above command.  
+If you use [`Linuxbrew`](https://docs.brew.sh/Homebrew-on-Linux) on Linux, you can install via the above command.  
 
 ### CentOS
 ```sh

--- a/wiki.md
+++ b/wiki.md
@@ -10,7 +10,12 @@ you have to install go and set $GOPATH and $GOBIN to ~/.bashrc.
 
 ## 1. Install go
 
-### Mac/Linuxbrew
+### Mac
+```sh
+brew intall golang
+```
+
+### Linuxbrew
 ```sh
 brew intall golang
 ```
@@ -50,7 +55,12 @@ please see docker official install guide and install docker.
 https://www.docker.com/get-started  
 
 ## 3. Install Git
-### Mac/Linuxbrew
+### Mac
+```sh
+brew install git
+```
+
+### Linuxbrew
 ```sh
 brew install git
 ```

--- a/wiki.md
+++ b/wiki.md
@@ -15,9 +15,19 @@ you have to install go and set $GOPATH and $GOBIN to ~/.bashrc.
 brew intall golang
 ```
 
-### Linux
+### CentOS
 ```sh
 yum install golang
+```
+
+### Debian/Ubuntu
+```sh
+apt install golang
+```
+
+### Fedora
+```sh
+dnf install golang
 ```
 
 ### Add ~/.bashrc
@@ -45,9 +55,19 @@ https://www.docker.com/get-started
 brew install git
 ```
 
-### Linux
+### CentOS
 ```sh
 yum install git
+```
+
+### Debian/Ubuntu
+```sh
+apt install git
+```
+
+### Fedora
+```sh
+dnf install git
 ```
 
 ## 3. Install docui

--- a/wiki.md
+++ b/wiki.md
@@ -10,7 +10,7 @@ you have to install go and set $GOPATH and $GOBIN to ~/.bashrc.
 
 ## 1. Install go
 
-### Mac
+### Mac/Linuxbrew
 ```sh
 brew intall golang
 ```
@@ -50,7 +50,7 @@ please see docker official install guide and install docker.
 https://www.docker.com/get-started  
 
 ## 3. Install Git
-### Mac
+### Mac/Linuxbrew
 ```sh
 brew install git
 ```

--- a/wiki.md
+++ b/wiki.md
@@ -55,7 +55,7 @@ https://www.docker.com/get-started
 ```sh
 brew install git
 ```
-If you use `Linuxbrew` on Linux, you can install via the above command.  
+If you use [`Linuxbrew`](https://docs.brew.sh/Homebrew-on-Linux) on Linux, you can install via the above command.  
 
 ### CentOS
 ```sh


### PR DESCRIPTION
Does docui support all Linux distributions that can use docker?

On wiki, the installation method for Linux supported only CentOS.
So I added for Linux distributions that can use docker, other than CentOS.

If it have support, please consider this pull-request : ) 
