### PR TITLE
Modernize goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,34 +1,40 @@
 project_name: docui
+
 builds:
-- env:
-  - CGO_ENABLED=0
-  - GO111MODULE=on
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    386: i386
-    amd64: x86_64
+  - env:
+    - CGO_ENABLED=0
+    - GO111MODULE=on
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ .Tag }}-next"
+
 changelog:
   skip: true
-brew:
-  name: docui
-  github:
-    owner: skanehira
-    name: homebrew-docui
-  folder: Formula
-  description: "TUI Client for Docker"
-  homepage: "https://github.com/skanehira/docui"
-  commit_author:
-    name: goreleaserbot
-    email: goreleaser@carlosbecker.com
-  dependencies:
-    - go
-  install: |
-    bin.install "docui"
-  test: |
-    system "#{bin}/docui"
+
+brews:
+  - name: docui
+    github:
+      owner: skanehira
+      name: homebrew-docui
+    folder: Formula
+    description: "TUI Client for Docker"
+    homepage: "https://github.com/skanehira/docui"
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@carlosbecker.com
+    dependencies:
+      - go
+    install: |
+      bin.install "docui"
+    test: |
+      system "#{bin}/docui"


### PR DESCRIPTION
`goreleaser` made some [deprecations](https://goreleaser.com/deprecations/).
This PR aims to comply with newer conventions.

Also by making those changes, generated homebrew formula will also support linux which is the main reason for this PR to be honest.