### PR TITLE
Open in browser

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -71,6 +71,21 @@ func ParsePortToString(ports []types.Port) string {
 	return port
 }
 
+// WebPort : first published ip and port is assumed to be a http port that can be opened in browser
+func WebPort(ports []types.Port) string {
+	for _, p := range ports {
+		if p.PublicPort != 0  {
+			publishedIp := p.IP
+			if publishedIp == "0.0.0.0" {
+				publishedIp = "localhost"
+			}
+			publishedWebPort := fmt.Sprintf("%s:%d", publishedIp, p.PublicPort)
+			return publishedWebPort
+		}
+	}
+	return ""
+}
+
 // ParseRepoTag parse image repo and tag.
 func ParseRepoTag(repoTag string) (string, string) {
 	tmp := strings.Split(repoTag, ":")

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/rivo/tview v0.0.0-20210312174852-ae9464cc3598
 	github.com/sirupsen/logrus v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23 h1:dofHuld+js7eKSemxqTVIo8yRlpRw+H1SdpzZxWruBc=
+github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/gui/containers.go
+++ b/gui/containers.go
@@ -18,6 +18,7 @@ type container struct {
 	Status  string
 	Created string
 	Port    string
+	WebPort string
 }
 
 type containers struct {
@@ -70,6 +71,8 @@ func (c *containers) setKeybinding(g *Gui) {
 			g.exportContainerForm()
 		case 'c':
 			g.commitContainerForm()
+		case 'w':
+			g.openBrowser()
 		}
 
 		return event
@@ -96,6 +99,7 @@ func (c *containers) entries(g *Gui) {
 			Status:  con.Status,
 			Created: common.ParseDateToString(con.Created),
 			Port:    common.ParsePortToString(con.Ports),
+			WebPort: common.WebPort(con.Ports),
 		})
 	}
 }

--- a/gui/keybindings.go
+++ b/gui/keybindings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/gdamore/tcell/v2"
+	"github.com/pkg/browser"
 	"github.com/rivo/tview"
 	"github.com/skanehira/docui/common"
 	"github.com/skanehira/docui/docker"
@@ -562,6 +563,15 @@ func (g *Gui) commitContainerForm() {
 		})
 
 	g.pages.AddAndSwitchToPage("form", g.modal(form, 80, 11), true).ShowPage("main")
+}
+
+func (g *Gui) openBrowser() {
+	container := g.selectedContainer()
+	if container.WebPort == "" {
+		return
+	}
+	link := "http://" + container.WebPort
+	browser.OpenURL(link)
 }
 
 func (g *Gui) commitContainer(repo, tag, container string) {

--- a/gui/navigate.go
+++ b/gui/navigate.go
@@ -15,7 +15,7 @@ func newNavigate() *navigate {
 		TextView: tview.NewTextView().SetTextColor(tcell.ColorYellow),
 		keybindings: map[string]string{
 			"images":     " p: pull image, i: import image, s: save image, Ctrl+l: load image, f: search image, /: filter d: remove image,\n c: create container, Enter: inspect image, Ctrl+r: refresh images list",
-			"containers": " e: export container, c: commit container, /: filter, Ctrl+e: exec container cmd u: start container, s: stop container,\n Ctrl+k: kill container, d: remove container, Enter: inspect container, Ctrl+r: refresh container list, Ctrl+l: show container logs",
+			"containers": " e: export container, c: commit container, /: filter, Ctrl+e: exec container cmd, w: open in browser (first port is http), u: start container, s: stop container,\n Ctrl+k: kill container, d: remove container, Enter: inspect container, Ctrl+r: refresh container list, Ctrl+l: show container logs",
 			"networks":   " d: remove network, Enter: inspect network, /: filter",
 			"volumes":    " c: create volume, d: remove volume\n /: filter, Enter: inspect volume, Ctrl+r: refresh volume list",
 		},


### PR DESCRIPTION
Most containers expose some http port. We can open it in browser.
For simplicity we can just open first container's published port.
We'll determine the ip:port on container creation and store to meta "Web Port".
To open browser on any platform was added a new dependency github.com/pkg/browser which is very small.

The similar functionality already exists in DockerStation
