### PR TITLE
Fix shortcut info for kill container

### DIFF
--- a/gui/navigate.go
+++ b/gui/navigate.go
@@ -15,7 +15,7 @@ func newNavigate() *navigate {
 		TextView: tview.NewTextView().SetTextColor(tcell.ColorYellow),
 		keybindings: map[string]string{
 			"images":     " p: pull image, i: import image, s: save image, Ctrl+l: load image, f: search image, /: filter d: remove image,\n c: create container, Enter: inspect image, Ctrl+r: refresh images list",
-			"containers": " e: export container, c: commit container, /: filter, Ctrl+e: exec container cmd u: start container, s: stop container,\n Ctrl+l: kill container, d: remove container, Enter: inspect container, Ctrl+r: refresh container list, Ctrl+l: show container logs",
+			"containers": " e: export container, c: commit container, /: filter, Ctrl+e: exec container cmd u: start container, s: stop container,\n Ctrl+k: kill container, d: remove container, Enter: inspect container, Ctrl+r: refresh container list, Ctrl+l: show container logs",
 			"networks":   " d: remove network, Enter: inspect network, /: filter",
 			"volumes":    " c: create volume, d: remove volume\n /: filter, Enter: inspect volume, Ctrl+r: refresh volume list",
 		},


### PR DESCRIPTION
Fixed a typo in shortcut message after actually trying to kill a container with `Ctrl-l` :)